### PR TITLE
[feature] #2 아티스트 조회(친구목록) API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,24 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // 쿼리 파라미터 로그 남기기
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
+++ b/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum SuccessMessage {
 
-  BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다.");
+  BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다."),
+  ARTIST_MEMBER_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 멤버 목록 조회 성공했습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
+++ b/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
@@ -1,14 +1,39 @@
 package com.sopt.mobile.controller;
 
+import com.sopt.mobile.common.dto.SuccessMessage;
+import com.sopt.mobile.common.dto.SuccessStatusResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/vi/artists/members/friend")
 @RequiredArgsConstructor
-@Validated
 public class ArtistMemberController {
+
+  private final ArtistMemberService ArtistMemberService;
+
+  @GetMapping("")
+  public ApiResponse<MemberResponseDto.nicknameDto> getSubscribedArtists(
+      @RequestHeader(name = "memberId") Long memberId){
+
+    return SuccessStatusResponse.of(
+        HttpStatus.OK,
+        SuccessMessage.
+        ArtistMemberService.findSubscribedArtists(memberId));
+
+    if(!memberRequestDto.getNickname().isEmpty()) {
+      MemberResponseDto.nicknameDto result = memberService.patchNickname(member, memberRequestDto);
+      return ApiResponse.onSuccess(result);
+    } else
+      throw new ExceptionHandler(NICKNAME_EMPTY);
+  }
+
 
 }

--- a/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
+++ b/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
@@ -2,12 +2,11 @@ package com.sopt.mobile.controller;
 
 import com.sopt.mobile.common.dto.SuccessMessage;
 import com.sopt.mobile.common.dto.SuccessStatusResponse;
+import com.sopt.mobile.service.ArtistMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,23 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ArtistMemberController {
 
-  private final ArtistMemberService ArtistMemberService;
+  private final ArtistMemberService artistMemberService;
 
   @GetMapping("")
-  public ApiResponse<MemberResponseDto.nicknameDto> getSubscribedArtists(
+  public ResponseEntity<SuccessStatusResponse> getSubscribedArtists(
       @RequestHeader(name = "memberId") Long memberId){
 
-    return SuccessStatusResponse.of(
-        HttpStatus.OK,
-        SuccessMessage.
-        ArtistMemberService.findSubscribedArtists(memberId));
-
-    if(!memberRequestDto.getNickname().isEmpty()) {
-      MemberResponseDto.nicknameDto result = memberService.patchNickname(member, memberRequestDto);
-      return ApiResponse.onSuccess(result);
-    } else
-      throw new ExceptionHandler(NICKNAME_EMPTY);
+    return ResponseEntity.ok(SuccessStatusResponse.of(
+        SuccessMessage.ARTIST_MEMBER_FIND_SUCCESS,
+        artistMemberService.findSubscribedArtists(memberId)));
   }
-
 
 }

--- a/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
+++ b/src/main/java/com/sopt/mobile/controller/ArtistMemberController.java
@@ -1,0 +1,14 @@
+package com.sopt.mobile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/vi/artists/members/friend")
+@RequiredArgsConstructor
+@Validated
+public class ArtistMemberController {
+
+}

--- a/src/main/java/com/sopt/mobile/repository/ArtistMemberQuerydslRepository.java
+++ b/src/main/java/com/sopt/mobile/repository/ArtistMemberQuerydslRepository.java
@@ -1,0 +1,12 @@
+package com.sopt.mobile.repository;
+
+import com.sopt.mobile.domain.ArtistMember;
+import com.sopt.mobile.domain.Member;
+import java.util.List;
+
+public interface ArtistMemberQuerydslRepository {
+
+  List<ArtistMember> findSubscribedArtists(Member member);
+
+  List<ArtistMember> findNotSubscribedArtists(Member member);
+}

--- a/src/main/java/com/sopt/mobile/repository/ArtistMemberQuerydslRepositoryImpl.java
+++ b/src/main/java/com/sopt/mobile/repository/ArtistMemberQuerydslRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.sopt.mobile.repository;
+
+import static com.sopt.mobile.domain.QArtistMember.artistMember;
+import static com.sopt.mobile.domain.QSubscribedArtist.subscribedArtist;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sopt.mobile.domain.ArtistMember;
+import com.sopt.mobile.domain.Member;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+
+public class ArtistMemberQuerydslRepositoryImpl implements ArtistMemberQuerydslRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public ArtistMemberQuerydslRepositoryImpl(EntityManager em) {
+    this.queryFactory = new JPAQueryFactory(em);
+  }
+
+  @Override
+  public List<ArtistMember> findSubscribedArtists(Member member) {
+    return queryFactory
+        .selectFrom(artistMember)
+        .where(artistMember.in(
+            queryFactory
+                .select(subscribedArtist.artistMember)
+                .from(subscribedArtist)
+                .where(subscribedArtist.member.eq(member))
+        ))
+        .fetch();
+  }
+
+  @Override
+  public List<ArtistMember> findNotSubscribedArtists(Member member) {
+    return queryFactory
+        .selectFrom(artistMember)
+        .where(artistMember.notIn(
+            queryFactory
+                .select(subscribedArtist.artistMember)
+                .from(subscribedArtist)
+                .where(subscribedArtist.member.eq(member))
+        ))
+        .fetch();
+  }
+}

--- a/src/main/java/com/sopt/mobile/repository/ArtistMemberRepository.java
+++ b/src/main/java/com/sopt/mobile/repository/ArtistMemberRepository.java
@@ -1,0 +1,8 @@
+package com.sopt.mobile.repository;
+
+import com.sopt.mobile.domain.ArtistMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtistMemberRepository extends JpaRepository<ArtistMember, Long>, ArtistMemberQuerydslRepository {
+
+}

--- a/src/main/java/com/sopt/mobile/repository/ArtistMemberRepository.java
+++ b/src/main/java/com/sopt/mobile/repository/ArtistMemberRepository.java
@@ -1,8 +1,0 @@
-package com.sopt.mobile.repository;
-
-import com.sopt.mobile.domain.ArtistMember;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ArtistMemberRepository extends JpaRepository<ArtistMember, Long> {
-
-}

--- a/src/main/java/com/sopt/mobile/service/ArtistMemberService.java
+++ b/src/main/java/com/sopt/mobile/service/ArtistMemberService.java
@@ -1,0 +1,10 @@
+package com.sopt.mobile.service;
+
+import com.sopt.mobile.service.dto.response.ArtistMemberFindDto;
+import com.sopt.mobile.service.dto.response.ArtistMemberListFindDto;
+
+public interface ArtistMemberService {
+
+  ArtistMemberListFindDto findSubscribedArtists(Long memberId);
+
+}

--- a/src/main/java/com/sopt/mobile/service/ArtistMemberServiceImpl.java
+++ b/src/main/java/com/sopt/mobile/service/ArtistMemberServiceImpl.java
@@ -1,0 +1,39 @@
+package com.sopt.mobile.service;
+
+import com.sopt.mobile.common.dto.ErrorMessage;
+import com.sopt.mobile.domain.ArtistMember;
+import com.sopt.mobile.domain.Member;
+import com.sopt.mobile.exception.NotFoundException;
+import com.sopt.mobile.repository.ArtistMemberRepository;
+import com.sopt.mobile.repository.MemberRepository;
+import com.sopt.mobile.service.dto.response.ArtistMemberFindDto;
+import com.sopt.mobile.service.dto.response.ArtistMemberListFindDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistMemberServiceImpl implements ArtistMemberService{
+
+  private final MemberRepository memberRepository;
+  private final ArtistMemberRepository artistMemberRepository;
+
+  @Override
+  public ArtistMemberListFindDto findSubscribedArtists(Long memberId) {
+
+    // 멤버 찾기
+    Member findMember = memberRepository.findById(memberId).orElseThrow(
+        () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
+    );
+
+    // 아티스트 찾기
+    List<ArtistMemberFindDto> isSubsArtists =  artistMemberRepository.findSubscribedArtists(findMember)
+        .stream().map(ArtistMemberFindDto::of).toList();
+
+    List<ArtistMemberFindDto> isNotSubscribedArtists =  artistMemberRepository.findNotSubscribedArtists(findMember)
+        .stream().map(ArtistMemberFindDto::of).toList();
+
+    return ArtistMemberListFindDto.of(isSubsArtists, isNotSubscribedArtists);
+  }
+}

--- a/src/main/java/com/sopt/mobile/service/dto/response/ArtistMemberFindDto.java
+++ b/src/main/java/com/sopt/mobile/service/dto/response/ArtistMemberFindDto.java
@@ -1,0 +1,21 @@
+package com.sopt.mobile.service.dto.response;
+
+import com.sopt.mobile.domain.ArtistMember;
+
+public record ArtistMemberFindDto(
+    Long artistMemberId,
+    String name,
+    String imageURL,
+    String introduction
+) {
+
+  public static ArtistMemberFindDto of(
+      ArtistMember artistMember
+  ) {
+    return new ArtistMemberFindDto(
+        artistMember.getId(),
+        artistMember.getName(),
+        artistMember.getImageURL(),
+        artistMember.getIntroduction());
+  }
+}

--- a/src/main/java/com/sopt/mobile/service/dto/response/ArtistMemberListFindDto.java
+++ b/src/main/java/com/sopt/mobile/service/dto/response/ArtistMemberListFindDto.java
@@ -1,0 +1,19 @@
+package com.sopt.mobile.service.dto.response;
+
+import com.sopt.mobile.domain.ArtistMember;
+import java.util.List;
+
+public record ArtistMemberListFindDto(
+    List<ArtistMemberFindDto> isSubsArtists,
+    List<ArtistMemberFindDto> isNotSubsArtists
+
+    ) {
+
+    public static ArtistMemberListFindDto of(
+        List<ArtistMemberFindDto> isSubsArtists,  List<ArtistMemberFindDto> isNotSubsArtists
+    ) {
+        return new ArtistMemberListFindDto(
+            isSubsArtists, isNotSubsArtists
+        );
+    }
+}


### PR DESCRIPTION
-closes #2

# 구현 내용❗️

### API 명세서
[API 명세서 링크](https://www.notion.so/sopt-official/64da216ef7de4cb0a0ae80955f34efcb?pvs=4)

# 요구사항 분석 ❗️
- 친구목록에서 아티스트 조회
- 구독한 아티스트/아닌 아티스트를 구별해주어야함

### 리턴된 데이터
``` json
{
    "status": 200,
    "success": true,
    "message": "아티스트 멤버 목록 조회 성공했습니다.",
    "result": {
        "isSubsArtists": [
            {
                "artistMemberId": 4,
                "name": "예지\n",
                "imageURL": "elwkjr.jpg",
                "introduction": "예지임"
            }
        ],
        "isNotSubsArtists": [
            {
                "artistMemberId": 1,
                "name": "원필\n",
                "imageURL": "dfkj.jpg",
                "introduction": "ㅇ"
            },
            {
                "artistMemberId": 3,
                "name": "유나",
                "imageURL": "dfd.jpg",
                "introduction": "유나임"
            }
        ]
    }
}
```

### 발생한 쿼리

``` sql
select am1_0.id,am1_0.artist_id,am1_0.create_at,am1_0.imageurl,am1_0.introduction,am1_0.is_service,am1_0.name,am1_0.update_at 
from artist_member am1_0 where am1_0.id in (select sa1_0.artist_member_id from subscribed_artist sa1_0 
where sa1_0.member_id=5) and am1_0.is_service=true;

select am1_0.id,am1_0.artist_id,am1_0.create_at,am1_0.imageurl,am1_0.introduction,am1_0.is_service,am1_0.name,am1_0.update_at 
from artist_member am1_0 where am1_0.id not in (select sa1_0.artist_member_id from subscribed_artist sa1_0 
where sa1_0.member_id=5) and am1_0.is_service=true;
```

### 작업 내용 1
#### DTO 생성
```java
public record ArtistMemberFindDto(
    Long artistMemberId,
    String name,
    String imageURL,
    String introduction
) {

  public static ArtistMemberFindDto of(
      ArtistMember artistMember
  ) {
    return new ArtistMemberFindDto(
        artistMember.getId(),
        artistMember.getName(),
        artistMember.getImageURL(),
        artistMember.getIntroduction());
  }
}
```

```java
public record ArtistMemberListFindDto(
    List<ArtistMemberFindDto> isSubsArtists,
    List<ArtistMemberFindDto> isNotSubsArtists

    ) {

    public static ArtistMemberListFindDto of(
        List<ArtistMemberFindDto> isSubsArtists,  List<ArtistMemberFindDto> isNotSubsArtists
    ) {
        return new ArtistMemberListFindDto(
            isSubsArtists, isNotSubsArtists
        );
    }
}
```

#### repository
- Querydsl 사용했습니다.
- 서브쿼리이용해서 구독한 아티스트/구독하지 않은 아티스트 멤버 데이터 가져오도록 했습니다.
- isService가 false인 아티스트 멤버는 제외해줬습니다.

``` java
@Override
  public List<ArtistMember> findSubscribedArtists(Member member) {
    return queryFactory
        .selectFrom(artistMember)
        .where(artistMember.in(
            queryFactory
                .select(subscribedArtist.artistMember)
                .from(subscribedArtist)
                .where(subscribedArtist.member.eq(member))
        ), artistMember.isService.isTrue())
        .fetch();
  }

  @Override
  public List<ArtistMember> findNotSubscribedArtists(Member member) {
    return queryFactory
        .selectFrom(artistMember)
        .where(artistMember.notIn(
            queryFactory
                .select(subscribedArtist.artistMember)
                .from(subscribedArtist)
                .where(subscribedArtist.member.eq(member))
        ) , artistMember.isService.isTrue()
        )
        .fetch();
  }
```
#### Controller 
``` java
  @GetMapping("")
  public ResponseEntity<SuccessStatusResponse> getSubscribedArtists(
      @RequestHeader(name = "memberId") Long memberId){

    return ResponseEntity.ok(SuccessStatusResponse.of(
        SuccessMessage.ARTIST_MEMBER_FIND_SUCCESS,
        artistMemberService.findSubscribedArtists(memberId)));
  }

```
#### Service
- 리포지토리에서 가져온 데이터를 DTO로 가공해서 컨트롤러에 리턴해주었습니다. 
``` java
@Override
  public ArtistMemberListFindDto findSubscribedArtists(Long memberId) {

    // 멤버 찾기
    Member findMember = memberRepository.findById(memberId).orElseThrow(
        () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
    );

    // 아티스트 찾기
    List<ArtistMemberFindDto> isSubsArtists =  artistMemberRepository.findSubscribedArtists(findMember)
        .stream().map(ArtistMemberFindDto::of).toList();

    List<ArtistMemberFindDto> isNotSubscribedArtists =  artistMemberRepository.findNotSubscribedArtists(findMember)
        .stream().map(ArtistMemberFindDto::of).toList();

    return ArtistMemberListFindDto.of(isSubsArtists, isNotSubscribedArtists);
  }
```
### 작업 내용 2

# 구현 고민사항 ❗️
- querydsl 리턴 타입을 나중에 DTO로 바꾸고 싶습니다(시간 날때)
