### PR TITLE
[feature] #11 - 특정 아티스트 조회 API 구현

### DIFF
--- a/src/main/java/com/sopt/mobile/common/dto/ErrorMessage.java
+++ b/src/main/java/com/sopt/mobile/common/dto/ErrorMessage.java
@@ -10,7 +10,8 @@ public enum ErrorMessage {
 
   MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
   SUBSCRIBED_ARTIST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND.value(), "memberId, artistMemberId에 해당하는 구독 중인 아티스트가 존재하지 않습니다."),
-  ARTIST_MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 아티스트 멤버가 존재하지 않습니다.");
+  ARTIST_MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 아티스트 멤버가 존재하지 않습니다."),
+  ARTIST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 아티스트가 존재하지 않습니다.");;
 
 
   private final int status;

--- a/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
+++ b/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
@@ -14,7 +14,8 @@ public enum SuccessMessage {
   ARTISTS_FIND_SUCCESS(HttpStatus.FOUND.value(), "아티스트 목록 조회에 성공했습니다."),
   SUBSCRIBED_ARTISTS_DELETE_SUCCESS(HttpStatus.OK.value(), "구독 중인 아티스트 제거 성공했습니다."),
   ARTIST_MEMBER_DETAIL_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 멤버 프로필 조회 성공했습니다."),
-  SUBSCRIBED_ARTISTS_REGISTER_SUCCESS(HttpStatus.FOUND.value(), "아티스트 즐겨찾기에 성공했습니다.");
+  SUBSCRIBED_ARTISTS_REGISTER_SUCCESS(HttpStatus.FOUND.value(), "아티스트 즐겨찾기에 성공했습니다."),
+  ARTIST_FIND_SUCCESS(HttpStatus.FOUND.value(), "아티스트 조회에 성공했습니다.");
   
   private final int status;
   private final String message;

--- a/src/main/java/com/sopt/mobile/controller/ArtistController.java
+++ b/src/main/java/com/sopt/mobile/controller/ArtistController.java
@@ -6,10 +6,7 @@ import com.sopt.mobile.service.ArtistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +22,15 @@ public class ArtistController {
         return ResponseEntity
                 .status(HttpStatus.FOUND)
                 .body(SuccessStatusResponse.of(SuccessMessage.ARTISTS_FIND_SUCCESS, artistService.findArtists()));
+    }
+
+    @GetMapping("/{artistId}")
+    public ResponseEntity<SuccessStatusResponse> findArtist(
+            @RequestHeader Long memberId,
+            @PathVariable(name = "artistId") Long artistId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .body(SuccessStatusResponse.of(SuccessMessage.ARTIST_FIND_SUCCESS, artistService.findArtist(artistId)));
     }
 }

--- a/src/main/java/com/sopt/mobile/domain/Subscribe.java
+++ b/src/main/java/com/sopt/mobile/domain/Subscribe.java
@@ -1,0 +1,16 @@
+package com.sopt.mobile.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Subscribe {
+    String name;
+    Integer price;
+
+    public Subscribe(String name, Integer price) {
+        this.name = name;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/sopt/mobile/service/ArtistService.java
+++ b/src/main/java/com/sopt/mobile/service/ArtistService.java
@@ -1,22 +1,65 @@
 package com.sopt.mobile.service;
 
+import com.sopt.mobile.common.dto.ErrorMessage;
+import com.sopt.mobile.domain.Artist;
+import com.sopt.mobile.domain.ArtistMember;
+import com.sopt.mobile.domain.Subscribe;
+import com.sopt.mobile.exception.NotFoundException;
+import com.sopt.mobile.repository.ArtistMemberRepository;
 import com.sopt.mobile.repository.ArtistRepository;
+import com.sopt.mobile.service.dto.response.ArtistFindDto;
+import com.sopt.mobile.service.dto.response.ArtistFindResponseDto;
 import com.sopt.mobile.service.dto.response.ArtistsFindListResponseDto;
 import com.sopt.mobile.service.dto.response.ArtistsFindResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 @Service
 @RequiredArgsConstructor
 public class ArtistService {
 
     private final ArtistRepository artistRepository;
+    private final ArtistMemberRepository artistMemberRepository;
 
     public ArtistsFindListResponseDto findArtists() {
         return ArtistsFindListResponseDto.of(artistRepository.findAll().stream()
                 .map(ArtistsFindResponseDto::of)
                 .toList());
+    }
+
+    public ArtistFindResponseDto findArtist(Long artistId) {
+        Artist artist = artistRepository.findById(artistId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.ARTIST_NOT_FOUND_EXCEPTION)
+        );
+
+        List<ArtistMember> serviceArtistMembers = artist.getArtistMemberList().stream()
+                .filter(ArtistMember::isService)
+                .toList();
+
+        List<ArtistMember> notServiceArtistMembers = artist.getArtistMemberList().stream()
+                .filter(Predicate.not(ArtistMember::isService))
+                .toList();
+
+        List<Subscribe> subscribe = new ArrayList<Subscribe>();
+
+        for (int i = 0; i < serviceArtistMembers.size(); i++) {
+            subscribe.add(new Subscribe(Integer.toString(i + 1) +"인권", 10000 * (i + 1)));
+        }
+
+        List<String> isServiceMembers = new ArrayList<String>();
+        List<String> isNotServiceMembers = new ArrayList<String>();
+        for (int i = 0; i < serviceArtistMembers.size(); i++) {
+            isServiceMembers.add(serviceArtistMembers.get(i).getName());
+        }
+        for (int i = 0; i < notServiceArtistMembers.size(); i++) {
+            isNotServiceMembers.add(notServiceArtistMembers.get(i).getName());
+        }
+
+
+        return ArtistFindResponseDto.of(ArtistFindDto.of(artist, subscribe, isServiceMembers, isNotServiceMembers));
     }
 }

--- a/src/main/java/com/sopt/mobile/service/dto/response/ArtistFindDto.java
+++ b/src/main/java/com/sopt/mobile/service/dto/response/ArtistFindDto.java
@@ -1,0 +1,20 @@
+package com.sopt.mobile.service.dto.response;
+
+import com.sopt.mobile.domain.Artist;
+import com.sopt.mobile.domain.ArtistMember;
+import com.sopt.mobile.domain.Subscribe;
+
+import java.util.List;
+
+public record ArtistFindDto(
+        String name,
+        String description,
+        String photo,
+        List<Subscribe> subscribe,
+        List<String> isServiceMembers,
+        List<String> isNotServiceMembers
+) {
+    public static ArtistFindDto of(Artist artist, List<Subscribe> subscribe, List<String> isServiceMembers, List<String> isNotServiceMembers) {
+        return new ArtistFindDto(artist.getName(), artist.getDescription(), artist.getImageURL(), subscribe, isServiceMembers, isNotServiceMembers);
+    }
+}

--- a/src/main/java/com/sopt/mobile/service/dto/response/ArtistFindResponseDto.java
+++ b/src/main/java/com/sopt/mobile/service/dto/response/ArtistFindResponseDto.java
@@ -1,0 +1,14 @@
+package com.sopt.mobile.service.dto.response;
+
+import com.sopt.mobile.domain.Artist;
+import com.sopt.mobile.domain.Subscribe;
+
+import java.util.List;
+
+public record ArtistFindResponseDto(
+        ArtistFindDto artist
+) {
+    public static ArtistFindResponseDto of(ArtistFindDto artist) {
+        return new ArtistFindResponseDto(artist);
+    }
+}


### PR DESCRIPTION
<!-- 1. PR 제목 형식 : [type] #이슈번호-PR제목 -->
<!-- 2. 오른쪽에 태그 선택해주기(pr 대상, 작업 유형, 작업자)-->

-closes #11

# 구현 내용❗️
<!-- API 명세서, API Controller -->
<!-- 상세설명_ & 캡쳐 -->

### API 명세서
API 명세서 링크 https://www.notion.so/sopt-official/f9617c275e614b84a0da110479e165d7?pvs=4

### ArtistService

https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/35e00e7537c7421fbb8ab4c86981c4782e89ec66/src/main/java/com/sopt/mobile/service/ArtistService.java#L34-L63

### ArtistFindDto

https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/35e00e7537c7421fbb8ab4c86981c4782e89ec66/src/main/java/com/sopt/mobile/service/dto/response/ArtistFindDto.java#L9-L20

### Subscibe

https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/35e00e7537c7421fbb8ab4c86981c4782e89ec66/src/main/java/com/sopt/mobile/domain/Subscribe.java#L6-L16

# 요구사항 분석 ❗️
<!-- 동작 Flow -->
### 특정 아티스트 조회 API 구현

![image](https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/assets/127496156/7d518768-6324-46e1-9b1b-9c43179d0d7f)


# 구현 고민사항 ❗️
<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->

### Subscibe 도메인
* 버블 서비스를 사용하는 아티스트 수에 따라 구독권을 관리해야 하는 경우가 있고, 그 아티스트 멤버들을 분리해야 했는데 Dto를 위해 Subscribe 클래스를 하나 만들었습니다. 지금은 List를 만들어 구현하였지만 이후 리팩토링 과정을 통해 테이블을 조인하는 방식으로 좀 더 좋은 코드를 작성해보고 싶습니다. 또한 임시로 저장하는 Subscribe는 도메인이 아니라 inner Class를 이용해도 좋을 것 같다고 생각했습니다.



...
