### PR TITLE
[type] #11 - 상태코드 수정, 할인 적용 가격 수정 및 Subscribe 도메인 수정

### DIFF
--- a/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
+++ b/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java
@@ -11,11 +11,11 @@ public enum SuccessMessage {
 
   BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다."),
   ARTIST_MEMBER_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 멤버 목록 조회 성공했습니다."),
-  ARTISTS_FIND_SUCCESS(HttpStatus.FOUND.value(), "아티스트 목록 조회에 성공했습니다."),
+  ARTISTS_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 목록 조회에 성공했습니다."),
   SUBSCRIBED_ARTISTS_DELETE_SUCCESS(HttpStatus.OK.value(), "구독 중인 아티스트 제거 성공했습니다."),
   ARTIST_MEMBER_DETAIL_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 멤버 프로필 조회 성공했습니다."),
-  SUBSCRIBED_ARTISTS_REGISTER_SUCCESS(HttpStatus.FOUND.value(), "아티스트 즐겨찾기에 성공했습니다."),
-  ARTIST_FIND_SUCCESS(HttpStatus.FOUND.value(), "아티스트 조회에 성공했습니다.");
+  SUBSCRIBED_ARTISTS_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "아티스트 즐겨찾기에 성공했습니다."),
+  ARTIST_FIND_SUCCESS(HttpStatus.OK.value(), "아티스트 조회에 성공했습니다.");
   
   private final int status;
   private final String message;

--- a/src/main/java/com/sopt/mobile/domain/Subscribe.java
+++ b/src/main/java/com/sopt/mobile/domain/Subscribe.java
@@ -7,10 +7,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Subscribe {
     String name;
+    Integer previousPrice;
     Integer price;
 
-    public Subscribe(String name, Integer price) {
+    public Subscribe(String name, Integer previousPrice, Integer price) {
         this.name = name;
+        this.previousPrice = previousPrice;
         this.price = price;
     }
 }

--- a/src/main/java/com/sopt/mobile/service/ArtistService.java
+++ b/src/main/java/com/sopt/mobile/service/ArtistService.java
@@ -47,7 +47,7 @@ public class ArtistService {
         List<Subscribe> subscribe = new ArrayList<Subscribe>();
 
         for (int i = 0; i < serviceArtistMembers.size(); i++) {
-            subscribe.add(new Subscribe(Integer.toString(i + 1) +"인권", 10000 * (i + 1)));
+            subscribe.add(new Subscribe(Integer.toString(i + 1) +"인권", 4500 * (i + 1), 4500 * (i + 1) - 1000 * (i)));
         }
 
         List<String> isServiceMembers = new ArrayList<String>();

--- a/src/test/java/com/sopt/mobile/ArtistServiceTest.java
+++ b/src/test/java/com/sopt/mobile/ArtistServiceTest.java
@@ -1,0 +1,23 @@
+package com.sopt.mobile;
+
+import com.sopt.mobile.domain.Subscribe;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ArtistServiceTest {
+
+    @Test
+    @DisplayName("할인율 계산")
+    public void discount() {
+        int n = 2;
+        Subscribe subscribe = new Subscribe(Integer.toString(n) + "인권", 4500 * (n), 4500 * (n) - 1000 * (n - 1));
+        Assertions.assertThat(subscribe.getPrice()).isEqualTo(8000);
+
+        n = 4;
+        Subscribe subscribe2 = new Subscribe(Integer.toString(n) + "인권", 4500 * (n), 4500 * (n) - 1000 * (n - 1));
+        Assertions.assertThat(subscribe2.getPrice()).isEqualTo(15000);
+        Assertions.assertThat(subscribe2.getPreviousPrice()).isEqualTo(18000);
+
+    }
+}


### PR DESCRIPTION
<!-- 1. PR 제목 형식 : [type] #이슈번호-PR제목 -->
<!-- 2. 오른쪽에 태그 선택해주기(pr 대상, 작업 유형, 작업자)-->

-closes #11 

# 구현 내용❗️
<!-- API 명세서, API Controller -->
<!-- 상세설명_ & 캡쳐 -->

### 상태코드 변경
https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/c6c9f284283c5713004365f6e98872e01c4e7e44/src/main/java/com/sopt/mobile/common/dto/SuccessMessage.java#L14-L18

### 할인율 적용 코드 변경

https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/c6c9f284283c5713004365f6e98872e01c4e7e44/src/main/java/com/sopt/mobile/domain/Subscribe.java#L8-L11

https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-Server/blob/c6c9f284283c5713004365f6e98872e01c4e7e44/src/main/java/com/sopt/mobile/service/ArtistService.java#L49-L51

# 요구사항 분석 ❗️
<!-- 동작 Flow -->

### 상태코드 변경 
* 단순 조회를 200번대로 반환 하도록 설정했습니다!
* POST작업 또한 CREATED로 반환하도록 했습니다!

### 할인 구현
* 인당 1000원 씩 할인 할 수 있도록 변경하였습니다!

# 구현 고민사항 ❗️

* 할인율을 조금 더 고민해서 리팩토링 시 적용해야 할 것 같습니다.
* Test파일을 만들어 보긴 했는데 아마 postman으로 확인을 한 번 더 해봐야 할 것 같습니다!
